### PR TITLE
Added new dependecies install command to README for succesful compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ qmake may have a different name on your distribution i.e. on Fedora it's called 
 
 Notes for building/running Debian/Raspbian:  In addition to the Linux build requirements, there are some additional requirements for running this QT application in order for the audio devices to be correctly detected:
 ```
-sudo apt-get install libqt5multimedia5-plugins
+sudo apt-get install libqt5multimedia5-plugins libqt5serialport5-dev qtmultimedia5-dev libqt5multimediawidgets5 libqt5multimedia5-plugins libqt5multimedia5
 ```
 And if pulseaudio is not currently installed:
 ```


### PR DESCRIPTION
On the latest Ubuntu Linux (and probably on majority of Debian variants) additional packages are needed for successful compilation otherwise the following error is shown after running qmake:
Project ERROR: Unknown module(s) in QT: serialport multimedia

I added the needed commands to the README file to install the missing packages  for successful compilation