### PR TITLE
Fix localisation issue in readyReadDMR

### DIFF
--- a/dudestar.cpp
+++ b/dudestar.cpp
@@ -2037,10 +2037,10 @@ void DudeStar::readyReadDMR()
 
 			connect_status = DMR_CONF;
 			char latitude[20U];
-			::sprintf(latitude, "%08f", 50.0f);
+			::sprintf(latitude, "50.00000");
 
 			char longitude[20U];
-			::sprintf(longitude, "%09f", 3.0f);
+			::sprintf(longitude, "03.000000");
 			::sprintf(buffer + 8U, "%-8.8s%09u%09u%02u%02u%8.8s%9.9s%03d%-20.20s%-19.19s%c%-124.124s%-40.40s%-40.40s", callsign.toStdString().c_str(),
 					438800000, 438800000, 1, 1, latitude, longitude, 0, "Detroit","USA", '2', "www.dudetronics.com", "20190131", "MMDVM");
 			out.append(buffer, 302);


### PR DESCRIPTION
When converting the latitude/longitude from float to string the resulting string can contain a comma instead of a decimal point, depending on localization settings (for example when using "de_DE.UTF-8").

This hard codes the result of the conversion.