### PR TITLE
Small fixes for AMBE_DEBUG-ging

### DIFF
--- a/ambe.c
+++ b/ambe.c
@@ -21,6 +21,10 @@
 //#include "ambe3600x2250_const.h"
 //#include "ambe3600x2400_const.h"
 
+#ifdef AMBE_DEBUG
+#include <stdio.h>
+#endif
+
 extern const float AmbePlusLtable[];
 extern const int AmbePlusVuv[16][8];
 extern const int AmbePlusLmprbl[57][4];
@@ -158,7 +162,7 @@ mbe_dequantizeAmbeParms (mbe_parms * cur_mp, mbe_parms * prev_mp, const int *b, 
 #endif
     }
 #ifdef AMBE_DEBUG
-  fprintf (atderr, "\nb0:%i w0:%f L:%i b1:%i\n", b0, cur_mp->w0, L, b1);
+  fprintf (stderr, "\nb0:%i w0:%f L:%i b1:%i\n", b0, cur_mp->w0, L, b1);
 #endif
   if (dstar) {
     deltaGamma = AmbePlusDg[b2];


### PR DESCRIPTION
Hi,

this fixes some typos when enabling AMBE_DEBUG macro. This patch makes it compile (and work well).